### PR TITLE
Add option to download soundtracks from YouTube using yt-dlp

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,4 @@ You can choose the format, the audio provider and the lyrics provider for the so
 - Choose the format of the audio file
 - Choose the audio provider
 - Choose the lyrics provider
+- Download soundtracks from YouTube using yt-dlp

--- a/templates/index.html
+++ b/templates/index.html
@@ -128,6 +128,7 @@
                         <option value="soundcloud">SoundCloud</option>
                         <option value="bandcamp">Bandcamp</option>
                         <option value="piped">Piped</option>
+                        <option value="yt-dlp">YouTube (yt-dlp)</option>
                     </select>
                 </div>
                 <div class="form-group col-md-4">


### PR DESCRIPTION
Fixes #4

Add functionality to download soundtracks from YouTube using yt-dlp.

* Add a new function `run_ytdlp` in `app.py` to handle YouTube downloads using yt-dlp.
* Update the `search` route in `app.py` to check for YouTube links and call `run_ytdlp` if detected.
* Update `VALID_AUDIO_PROVIDERS` in `app.py` to include 'yt-dlp'.
* Update `README.md` to mention the new feature of downloading soundtracks from YouTube using yt-dlp.
* Update `templates/index.html` to include an option for YouTube links in the search form.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/2Friendly4You/SpotifyDownloader/pull/5?shareId=6e40919f-be2e-4a80-8741-18b625a1784e).