### PR TITLE
feat(issue-template): update bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,103 +1,100 @@
-name: Bug report
-about: Create a report to help improve SpotifyDownloader
-title: '[BUG] '
+name: Bug Report
+
+title: Change this title, poorly formatted issues will not be handled
+
+description: Report bugs so we can fix them
+
 labels: bug
+
 assignees: 2Friendly4You
-description: File a bug report
+
 body:
-  - type: markdown
-    attributes:
-      value: |
-        Thanks for taking the time to fill out this bug report!
 
-  - type: textarea
-    id: bug_description
-    attributes:
-      label: Describe the bug
-      description: A clear and concise description of what the bug is.
-    validations:
-      required: true
+- type: dropdown
+  attributes:
+    label: System OS
+    description: OS not listed here? Please let us know below
+    options:
+      - Windows
+      - MacOS
+      - Linux
+      - Docker
+      - Termux (Android)
+      - Other
+  validations:
+    required: true
 
-  - type: textarea
-    id: reproduction_steps
-    attributes:
-      label: Steps to reproduce
-      description: How do you trigger this bug?
-      placeholder: |
-        1. Go to '...'
-        2. Click on '....'
-        3. Enter '....'
-        4. See error
-    validations:
-      required: true
+- type: dropdown
+  attributes:
+    label: Python Version
+    description: |
+      You can find your Python version by running `python -V` on your CLI
+      If you use a different Python version, please let us know below
+    options:
+      - 3.8 (CPython)
+      - 3.9 (CPython)
+      - 3.10 (CPython)
+      - 3.11 (CPython)
+      - 3.12 (CPython)
+      - 3.13 (CPython)
+      - Other
+  validations:
+    required: true
 
-  - type: textarea
-    id: expected_behavior
-    attributes:
-      label: Expected behavior
-      description: A clear and concise description of what you expected to happen.
-    validations:
-      required: true
+- type: dropdown
+  attributes:
+    label: Install Source
+    description: If installed from a different source, please let us know below
+    options:
+      - pip / PyPi
+      - GitHub
+      - Termux Installation Script (spotDL provided)
+      - Arch User Repository (Unofficial)
+      - Other
+  validations:
+    required: true
 
-  - type: dropdown
-    id: browsers
-    attributes:
-      label: Browser
-      description: What browsers are you seeing the problem on?
-      multiple: true
-      options:
-        - Firefox
-        - Chrome
-        - Safari
-        - Microsoft Edge
-        - Other
-    validations:
-      required: true
+- type: input
+  attributes:
+    label: Install version / commit hash
+    description: |
+      Supply version if installed from pip, found via `pip show spotdl`
+      or supply commit hash if installed from GitHub
+    placeholder: v4.x.x or hash-value
+  validations:
+    required: true
 
-  - type: dropdown
-    id: os
-    attributes:
-      label: Operating System
-      description: What operating system are you using?
-      options:
-        - Windows
-        - macOS
-        - Linux
-        - Other
-    validations:
-      required: true
+- type: textarea
+  attributes:
+    label: Expected Behavior vs Actual Behavior
+    placeholder: What did you expect and what actually happened? (Optional)
 
-  - type: input
-    id: version
-    attributes:
-      label: Version
-      description: What version of SpotifyDownloader are you running?
-    validations:
-      required: true
+- type: textarea
+  attributes:
+    label: Steps to reproduce - Ensure to include actual links!
+    placeholder: |
+      1.
+      2.
+      3.
+      ...
+  validations:
+    required: true
 
-  - type: textarea
-    id: screenshots
-    attributes:
-      label: Screenshots
-      description: If applicable, add screenshots to help explain your problem.
-    validations:
-      required: false
+- type: textarea
+  attributes:
+    label: Traceback
+    description: Copy and paste the complete output from spotDL
+    render: text
+    placeholder: Do this even if there is no error!
+  validations:
+    required: true
 
-  - type: textarea
-    id: additional_context
-    attributes:
-      label: Additional context
-      description: Add any other context about the problem here.
-    validations:
-      required: false
 
-  - type: checkboxes
-    id: terms
-    attributes:
-      label: Code of Conduct
-      description: By submitting this issue, you agree to follow our rules
-      options:
-        - label: I have searched existing issues and this has not been reported yet
-          required: true
-        - label: I am running the latest version of SpotifyDownloader
-          required: true
+- type: textarea
+  attributes:
+    label: Other details
+    placeholder: |
+      Note anything else you can provide regarding the issue you're running into.
+
+      If you didn't include your Python version, OS or installation source in the dropdowns
+      earlier, note said details here.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,67 +1,23 @@
-name: Feature request
-about: Suggest an idea for SpotifyDownloader
-title: '[FEATURE] '
+name: Feature Request
+
+title: Change this title, poorly formatted issues will not be handled
+
+description: Request a new feature
+
 labels: enhancement
+
 assignees: 2Friendly4You
-description: File a feature request
+
 body:
-  - type: dropdown
-    id: feature_type
-    attributes:
-      label: Feature Type
-      description: What type of feature are you suggesting?
-      options:
-        - UI/UX Improvement
-        - New Download Option
-        - Performance Enhancement
-        - Integration with Other Services
-        - Other
-    validations:
-      required: true
 
-  - type: textarea
-    id: problem_description
-    attributes:
-      label: Is your feature request related to a problem?
-      description: A clear and concise description of what the problem is.
-      placeholder: I'm always frustrated when [...]
-    validations:
-      required: true
+- type: textarea
+  attributes:
+    label: Requested Feature
+    placeholder: Describe the feature you would like to see implemented!
+  validations:
+    required: true
 
-  - type: textarea
-    id: solution_description
-    attributes:
-      label: Describe the solution you'd like
-      description: A clear and concise description of what you want to happen.
-    validations:
-      required: true
-
-  - type: textarea
-    id: alternatives
-    attributes:
-      label: Describe alternatives you've considered
-      description: A clear and concise description of any alternative solutions or features you've considered.
-    validations:
-      required: false
-
-  - type: dropdown
-    id: priority
-    attributes:
-      label: Priority Level
-      description: How important is this feature to you?
-      options:
-        - Critical
-        - High
-        - Medium
-        - Low
-        - Nice to have
-    validations:
-      required: true
-
-  - type: textarea
-    id: additional_context
-    attributes:
-      label: Additional context
-      description: Add any other context or screenshots about the feature request here.
-    validations:
-      required: false
+- type: textarea
+  attributes:
+    label: Possible implementation
+    placeholder: Describe a potential method of implementing this feature


### PR DESCRIPTION
The changes update the bug report template in the `.github/ISSUE_TEMPLATE/bug_report.yml` file. The main changes are:

- Simplify the title to be more concise and informative.
- Restructure the template to use more dropdowns and input fields to gather relevant information about the user's system and installation.
- Add more detailed instructions and placeholders to guide users in providing the necessary information for the bug report.
- Remove unnecessary sections and streamline the overall template to make it more user-friendly and easier to fill out.