### PR TITLE
feat(issue-templates): update issue templates to use YAML format

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,100 +1,109 @@
 name: Bug Report
-
-title: Change this title, poorly formatted issues will not be handled
-
-description: Report bugs so we can fix them
-
-labels: bug
-
-assignees: 2Friendly4You
-
+title: "[BUG] "
+description: Report a bug in SpotifyDownloader
+labels: ["bug"]
+assignees: ["2Friendly4You"]
 body:
+  - type: dropdown
+    attributes:
+      label: Operating System
+      description: What operating system are you using?
+      options:
+        - Windows
+        - macOS
+        - Linux
+        - Docker
+        - Other
+    validations:
+      required: true
 
-- type: dropdown
-  attributes:
-    label: System OS
-    description: OS not listed here? Please let us know below
-    options:
-      - Windows
-      - MacOS
-      - Linux
-      - Docker
-      - Termux (Android)
-      - Other
-  validations:
-    required: true
+  - type: dropdown
+    attributes:
+      label: Browser
+      description: What browser are you using?
+      options:
+        - Chrome
+        - Firefox
+        - Safari
+        - Edge
+        - Other
+    validations:
+      required: true
 
-- type: dropdown
-  attributes:
-    label: Python Version
-    description: |
-      You can find your Python version by running `python -V` on your CLI
-      If you use a different Python version, please let us know below
-    options:
-      - 3.8 (CPython)
-      - 3.9 (CPython)
-      - 3.10 (CPython)
-      - 3.11 (CPython)
-      - 3.12 (CPython)
-      - 3.13 (CPython)
-      - Other
-  validations:
-    required: true
+  - type: input
+    attributes:
+      label: Browser Version
+      description: What version of the browser are you using?
+      placeholder: e.g., Chrome 96.0.4664.110
+    validations:
+      required: true
 
-- type: dropdown
-  attributes:
-    label: Install Source
-    description: If installed from a different source, please let us know below
-    options:
-      - pip / PyPi
-      - GitHub
-      - Termux Installation Script (spotDL provided)
-      - Arch User Repository (Unofficial)
-      - Other
-  validations:
-    required: true
+  - type: dropdown
+    attributes:
+      label: Issue Type
+      description: What type of issue are you experiencing?
+      options:
+        - Download not starting
+        - Download fails
+        - Audio quality issues
+        - UI/Display problems
+        - Performance issues
+        - Other
+    validations:
+      required: true
 
-- type: input
-  attributes:
-    label: Install version / commit hash
-    description: |
-      Supply version if installed from pip, found via `pip show spotdl`
-      or supply commit hash if installed from GitHub
-    placeholder: v4.x.x or hash-value
-  validations:
-    required: true
+  - type: textarea
+    attributes:
+      label: Bug Description
+      description: Please provide a clear description of the bug
+      placeholder: When I try to...
+    validations:
+      required: true
 
-- type: textarea
-  attributes:
-    label: Expected Behavior vs Actual Behavior
-    placeholder: What did you expect and what actually happened? (Optional)
+  - type: textarea
+    attributes:
+      label: Steps to Reproduce
+      description: How can we reproduce this issue?
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. Enter '...'
+        4. See error
+    validations:
+      required: true
 
-- type: textarea
-  attributes:
-    label: Steps to reproduce - Ensure to include actual links!
-    placeholder: |
-      1.
-      2.
-      3.
-      ...
-  validations:
-    required: true
+  - type: textarea
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+      placeholder: The download should have...
+    validations:
+      required: true
 
-- type: textarea
-  attributes:
-    label: Traceback
-    description: Copy and paste the complete output from spotDL
-    render: text
-    placeholder: Do this even if there is no error!
-  validations:
-    required: true
+  - type: textarea
+    attributes:
+      label: Error Message
+      description: If you received an error message, please copy and paste it here
+      render: shell
+    validations:
+      required: false
 
+  - type: textarea
+    attributes:
+      label: Screenshots
+      description: If applicable, add screenshots to help explain your problem
+      placeholder: Drag and drop images here
+    validations:
+      required: false
 
-- type: textarea
-  attributes:
-    label: Other details
-    placeholder: |
-      Note anything else you can provide regarding the issue you're running into.
-
-      If you didn't include your Python version, OS or installation source in the dropdowns
-      earlier, note said details here.
+  - type: checkboxes
+    attributes:
+      label: Verification
+      description: Please verify that you have completed these tasks
+      options:
+        - label: I am using the latest version of SpotifyDownloader
+          required: true
+        - label: I have checked that this issue hasn't been reported before
+          required: true
+        - label: I have cleared my browser cache and cookies
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,23 +1,54 @@
 name: Feature Request
-
-title: Change this title, poorly formatted issues will not be handled
-
-description: Request a new feature
-
-labels: enhancement
-
-assignees: 2Friendly4You
-
+title: "[FEATURE] "
+description: Suggest an idea for SpotifyDownloader
+labels: ["enhancement"]
+assignees: ["2Friendly4You"]
 body:
+  - type: dropdown
+    attributes:
+      label: Feature Category
+      description: What area of the application does this feature relate to?
+      options:
+        - Download Functionality
+        - User Interface
+        - Format Support
+        - Provider Integration
+        - Performance
+        - Other
+    validations:
+      required: true
 
-- type: textarea
-  attributes:
-    label: Requested Feature
-    placeholder: Describe the feature you would like to see implemented!
-  validations:
-    required: true
+  - type: textarea
+    attributes:
+      label: Feature Description
+      description: Describe the feature you would like to see added
+      placeholder: I would like to see...
+    validations:
+      required: true
 
-- type: textarea
-  attributes:
-    label: Possible implementation
-    placeholder: Describe a potential method of implementing this feature
+  - type: textarea
+    attributes:
+      label: Use Case
+      description: Describe how you would use this feature
+      placeholder: This would be useful when...
+    validations:
+      required: true
+
+  - type: dropdown
+    attributes:
+      label: Priority
+      description: How important is this feature to you?
+      options:
+        - Critical
+        - High
+        - Medium
+        - Low
+        - Nice to have
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Additional Context
+      description: Add any other context about the feature request here
+      placeholder: Screenshots, mock-ups, or additional details...

--- a/templates/index.html
+++ b/templates/index.html
@@ -138,12 +138,12 @@
     <footer class="footer">
         <div class="footer-content">
             <div class="footer-buttons">
-                <a href="https://github.com/2Friendly4You/SpotifyDownloader/issues/new?template=bug_report.md"
+                <a href="https://github.com/2Friendly4You/SpotifyDownloader/issues/new?template=bug_report.yml"
                     class="footer-button" target="_blank" rel="noopener">
                     <span class="material-symbols-outlined">bug_report</span>
                     Report Bug
                 </a>
-                <a href="https://github.com/2Friendly4You/SpotifyDownloader/issues/new?template=feature_request.md"
+                <a href="https://github.com/2Friendly4You/SpotifyDownloader/issues/new?template=feature_request.yml"
                     class="footer-button" target="_blank" rel="noopener">
                     <span class="material-symbols-outlined">lightbulb</span>
                     Feature Request


### PR DESCRIPTION
The changes update the issue templates for bug reports and feature requests to use the YAML format instead of Markdown. This provides a more structured and user-friendly experience for submitting issues. The key changes are:

- Updated the `feature_request.md` template to `feature_request.yml`
- Updated the `bug_report.md` template to `bug_report.yml`
- Standardized the title format for both templates to use the `[FEATURE]` and `[BUG]` prefixes
- Added more structured fields to the templates, such as feature category, priority, and additional context

These changes will improve the overall issue submission process and make it easier to triage and manage incoming bug reports and feature requests.